### PR TITLE
[Enhancement] Allow optional callback function to be passed to DefaultConsumer

### DIFF
--- a/amqprs/README.md
+++ b/amqprs/README.md
@@ -14,11 +14,12 @@ Yet another RabbitMQ client implementation in rust with different design goals.
 3. lock free: no mutex/lock in client library itself.
 
 # Design Architecture
+
 ![Lock-free Design](amqp-chosen_design.drawio.png)
 
 # Example: Consume and Publish
 
-## [Link to full example code](https://github.com/gftea/amqprs/blob/main/amqprs/examples/basic_pub_sub.rs) 
+## [Link to full example code](https://github.com/gftea/amqprs/blob/main/amqprs/examples/basic_pub_sub.rs)
 
 ```rust
 // open a connection to RabbitMQ server
@@ -63,12 +64,12 @@ channel
 //////////////////////////////////////////////////////////////////
 // start consumer with given name
 let args = BasicConsumeArguments::new(
-        &queue_name, 
+        &queue_name,
         "example_basic_pub_sub"
     );
 
 channel
-    .basic_consume(DefaultConsumer::new(args.no_ack), args)
+    .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
     .await
     .unwrap();
 
@@ -94,7 +95,7 @@ channel
 
 
 // channel/connection will be closed when drop.
-// keep the `channel` and `connection` object from dropping 
+// keep the `channel` and `connection` object from dropping
 // before pub/sub is done.
 time::sleep(time::Duration::from_secs(1)).await;
 // explicitly close

--- a/amqprs/examples/basic_consumer.rs
+++ b/amqprs/examples/basic_consumer.rs
@@ -64,7 +64,7 @@ async fn main() {
         .finish();
 
     channel
-        .basic_consume(DefaultConsumer::new(args.no_ack), args)
+        .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
         .await
         .unwrap();
 

--- a/amqprs/examples/basic_pub_sub.rs
+++ b/amqprs/examples/basic_pub_sub.rs
@@ -62,7 +62,7 @@ async fn main() {
     let args = BasicConsumeArguments::new(&queue_name, "example_basic_pub_sub");
 
     channel
-        .basic_consume(DefaultConsumer::new(args.no_ack), args)
+        .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
         .await
         .unwrap();
 

--- a/amqprs/examples/tls.rs
+++ b/amqprs/examples/tls.rs
@@ -91,7 +91,7 @@ async fn main() {
         let args = BasicConsumeArguments::new(&queue_name, "example_basic_pub_sub");
 
         channel
-            .basic_consume(DefaultConsumer::new(args.no_ack), args)
+            .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
             .await
             .unwrap();
 

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -765,7 +765,7 @@ mod tests {
                 .finish();
 
             channel
-                .basic_consume(DefaultConsumer::new(args.no_ack), args)
+                .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
                 .await
                 .unwrap();
             time::sleep(time::Duration::from_secs(1)).await;
@@ -801,7 +801,7 @@ mod tests {
 
             let args = BasicConsumeArguments::new(&queue_name, "test_manual_ack");
             channel
-                .basic_consume(DefaultConsumer::new(args.no_ack), args)
+                .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
                 .await
                 .unwrap();
             time::sleep(time::Duration::from_secs(1)).await;

--- a/amqprs/src/api/channel/dispatcher.rs
+++ b/amqprs/src/api/channel/dispatcher.rs
@@ -559,7 +559,7 @@ mod tests {
         // start consumer with no_wait = true
         let consumer_tag = consumer_channel
             .basic_consume(
-                DefaultConsumer::new(false),
+                DefaultConsumer::new(false, None),
                 BasicConsumeArguments::new(&queue_name, "purge-tester")
                     .no_wait(true)
                     .finish(),

--- a/amqprs/tests/test_heartbeat.rs
+++ b/amqprs/tests/test_heartbeat.rs
@@ -43,7 +43,7 @@ async fn test_customized_heartbeat() {
     let args = BasicConsumeArguments::new(&queue_name, "test_multi_consume");
 
     channel
-        .basic_consume(DefaultConsumer::new(args.no_ack), args)
+        .basic_consume(DefaultConsumer::new(args.no_ack, None), args)
         .await
         .unwrap();
 


### PR DESCRIPTION
Added an optional callback function that can be passed to DefaultConsumer. Added a passing test for callback fn. All previous uses of the DefaultConsumer provide a `None` argument to `DefaultConsumer::new`. Implemented Default trait for DefaultConsumer that does not use the callback function. 

I hope this is helpful. Please let me know if you would like me to make any changes or point out any issues.  