### PR TITLE
AMQP Support using uriparse.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "uriparse",
  "webpki-roots",
 ]
 
@@ -82,6 +83,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "hermit-abi"
@@ -422,6 +429,16 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
 
 [[package]]
 name = "valuable"

--- a/amqprs/Cargo.toml
+++ b/amqprs/Cargo.toml
@@ -22,6 +22,7 @@ default = []
 compliance_assert = []
 traces = ["tracing"]
 tls = ["tokio-rustls", "rustls-pemfile", "webpki-roots"]
+urispec = ["uriparse"]
 
 [dependencies]
 tokio = { version = "1.0", features = [
@@ -38,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 amqp_serde = { version = "0.2" }
 async-trait = "0.1"
 tracing = { version = "0.1", optional = true }
-uriparse = "0.6.4"
+uriparse = {veresion = "0.6.4", optional = true }
 
 # SSL/TLS dependencies
 tokio-rustls = {version = "0.23", optional = true}

--- a/amqprs/Cargo.toml
+++ b/amqprs/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 amqp_serde = { version = "0.2" }
 async-trait = "0.1"
 tracing = { version = "0.1", optional = true }
+url = "2.3.1"
 
 # SSL/TLS dependencies
 tokio-rustls = {version = "0.23", optional = true}

--- a/amqprs/Cargo.toml
+++ b/amqprs/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 amqp_serde = { version = "0.2" }
 async-trait = "0.1"
 tracing = { version = "0.1", optional = true }
-url = "2.3.1"
+uriparse = "0.6.4"
 
 # SSL/TLS dependencies
 tokio-rustls = {version = "0.23", optional = true}

--- a/amqprs/examples/basic_consumer.rs
+++ b/amqprs/examples/basic_consumer.rs
@@ -19,11 +19,7 @@ async fn main() {
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     // open a connection to RabbitMQ server
-    let connection = Connection::open(&OpenConnectionArguments::new(
-        "localhost:5672",
-        "user",
-        "bitnami",
-    ))
+    let connection = Connection::open(&OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami"))
     .await
     .unwrap();
     connection

--- a/amqprs/examples/basic_consumer.rs
+++ b/amqprs/examples/basic_consumer.rs
@@ -19,7 +19,12 @@ async fn main() {
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     // open a connection to RabbitMQ server
-    let connection = Connection::open(&OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami"))
+    let connection = Connection::open(&OpenConnectionArguments::new(
+        "localhost",
+        5672,
+        "user",
+        "bitnami",
+    ))
     .await
     .unwrap();
     connection

--- a/amqprs/examples/basic_pub_sub.rs
+++ b/amqprs/examples/basic_pub_sub.rs
@@ -20,7 +20,8 @@ async fn main() {
 
     // open a connection to RabbitMQ server
     let connection = Connection::open(&OpenConnectionArguments::new(
-        "localhost:5672",
+        "localhost",
+        Some(5672),
         "user",
         "bitnami",
     ))

--- a/amqprs/examples/basic_pub_sub.rs
+++ b/amqprs/examples/basic_pub_sub.rs
@@ -21,7 +21,7 @@ async fn main() {
     // open a connection to RabbitMQ server
     let connection = Connection::open(&OpenConnectionArguments::new(
         "localhost",
-        Some(5672),
+        5672,
         "user",
         "bitnami",
     ))

--- a/amqprs/examples/callbacks_impl.rs
+++ b/amqprs/examples/callbacks_impl.rs
@@ -56,7 +56,7 @@ impl ChannelCallback for ExampleChannelCallback {
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() {
     // open a connection to RabbitMQ server
-    let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
+    let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami");
 
     let connection = Connection::open(&args).await.unwrap();
     connection

--- a/amqprs/examples/callbacks_impl.rs
+++ b/amqprs/examples/callbacks_impl.rs
@@ -56,7 +56,7 @@ impl ChannelCallback for ExampleChannelCallback {
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() {
     // open a connection to RabbitMQ server
-    let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami");
+    let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
 
     let connection = Connection::open(&args).await.unwrap();
     connection

--- a/amqprs/examples/tls.rs
+++ b/amqprs/examples/tls.rs
@@ -39,7 +39,7 @@ async fn main() {
         // domain should match the certificate/key files
         let domain = "AMQPRS_TEST";
 
-        let args = OpenConnectionArguments::new("localhost:5671", "user", "bitnami")
+        let args = OpenConnectionArguments::new("localhost", Some(5671), "user", "bitnami")
             .tls_adaptor(
                 TlsAdaptor::with_client_auth(
                     Some(root_ca_cert.as_path()),

--- a/amqprs/examples/tls.rs
+++ b/amqprs/examples/tls.rs
@@ -39,7 +39,7 @@ async fn main() {
         // domain should match the certificate/key files
         let domain = "AMQPRS_TEST";
 
-        let args = OpenConnectionArguments::new("localhost", Some(5671), "user", "bitnami")
+        let args = OpenConnectionArguments::new("localhost", 5671, "user", "bitnami")
             .tls_adaptor(
                 TlsAdaptor::with_client_auth(
                     Some(root_ca_cert.as_path()),

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -727,7 +727,8 @@ mod tests {
             connection::{Connection, OpenConnectionArguments},
             consumer::DefaultConsumer,
         },
-        frame::BasicProperties, DELIVERY_MODE_TRANSIENT,
+        frame::BasicProperties,
+        DELIVERY_MODE_TRANSIENT,
     };
 
     use super::{BasicConsumeArguments, BasicPublishArguments};
@@ -739,7 +740,7 @@ mod tests {
             .finish();
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami")
+        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
             .connection_name("test_basic_consume_auto_ack")
             .finish();
         let connection = Connection::open(&args).await.unwrap();
@@ -778,7 +779,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic_consume_manual_ack() {
         {
-            let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami")
+            let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
                 .connection_name("test_basic_consume_manual_ack")
                 .finish();
 
@@ -813,7 +814,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic_publish() {
         {
-            let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami")
+            let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
                 .connection_name("test_basic_publish")
                 .finish();
 

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -740,7 +740,7 @@ mod tests {
             .finish();
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
+        let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami")
             .connection_name("test_basic_consume_auto_ack")
             .finish();
         let connection = Connection::open(&args).await.unwrap();
@@ -779,7 +779,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic_consume_manual_ack() {
         {
-            let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
+            let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami")
                 .connection_name("test_basic_consume_manual_ack")
                 .finish();
 
@@ -814,7 +814,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic_publish() {
         {
-            let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
+            let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami")
                 .connection_name("test_basic_publish")
                 .finish();
 

--- a/amqprs/src/api/channel/dispatcher.rs
+++ b/amqprs/src/api/channel/dispatcher.rs
@@ -518,7 +518,7 @@ mod tests {
     async fn test_purge_consumer_resource() {
         let _guard = setup_logging(Level::INFO);
 
-        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
+        let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami");
         let connection = Connection::open(&args).await.unwrap();
 
         let exchange_name = "amq.topic";

--- a/amqprs/src/api/channel/dispatcher.rs
+++ b/amqprs/src/api/channel/dispatcher.rs
@@ -518,7 +518,7 @@ mod tests {
     async fn test_purge_consumer_resource() {
         let _guard = setup_logging(Level::INFO);
 
-        let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami");
+        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
         let connection = Connection::open(&args).await.unwrap();
 
         let exchange_name = "amq.topic";

--- a/amqprs/src/api/channel/exchange.rs
+++ b/amqprs/src/api/channel/exchange.rs
@@ -441,7 +441,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_exchange_declare() {
-        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
+        let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami");
 
         let connection = Connection::open(&args).await.unwrap();
         connection
@@ -467,7 +467,7 @@ mod tests {
     #[tokio::test]
     #[should_panic = "InternalChannelError(\"channel closed\")"]
     async fn test_exchange_delete() {
-        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
+        let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami");
 
         let connection = Connection::open(&args).await.unwrap();
         connection

--- a/amqprs/src/api/channel/exchange.rs
+++ b/amqprs/src/api/channel/exchange.rs
@@ -441,7 +441,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_exchange_declare() {
-        let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami");
+        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
 
         let connection = Connection::open(&args).await.unwrap();
         connection
@@ -467,7 +467,7 @@ mod tests {
     #[tokio::test]
     #[should_panic = "InternalChannelError(\"channel closed\")"]
     async fn test_exchange_delete() {
-        let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami");
+        let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
 
         let connection = Connection::open(&args).await.unwrap();
         connection

--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -416,6 +416,7 @@ impl OpenConnectionArguments {
     }
 }
 
+#[cfg(feature = "urispec")]
 impl TryFrom<&str> for OpenConnectionArguments {
     type Error = Error;
 

--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -445,11 +445,9 @@ impl TryFrom<&str> for OpenConnectionArguments {
         }
 
 
-
-
         // Set the default port depending on the scheme. The unwrap should be safe due to the checks above. 
         // Will panic if any invalid scheme is not rejected before this point
-        let default_port: u16 = match pu.scheme().unwrap().as_str() {
+        let default_port: u16 = match scheme {
             "amqp" => DEFAULT_AMQP_PORT,
             "amqps" => DEFAULT_AMQPS_PORT,
             _ => panic!("Error occurred while setting default port based on amq scheme. This should never happen.")
@@ -458,19 +456,6 @@ impl TryFrom<&str> for OpenConnectionArguments {
 
         // Check authority
         let pu_authority  = pu.authority().ok_or_else(|| Error::UriError(String::from("Invalid URI authority")))?;
-
-        // Check username
-        // let mut pu_authority_username: Option<&str> = None;
-        // if let Some(pu_a_u) = pu_authority.username() {
-        //     pu_authority_username = Some(pu_a_u.as_str());
-        // }
-
-        // Check password
-        // let mut pu_authority_password: Option<&str> = None;
-        // if let Some(pu_a_p) = pu_authority.password() {
-        //     pu_authority_password = Some(pu_a_p.as_str());
-        // }
-
         let pu_authority_username = pu_authority.username().map(|v| v.as_str()).unwrap_or_else(|| "guest");
         let pu_authority_password = pu_authority.password().map(|v| v.as_str()).unwrap_or_else(|| "guest");
 

--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -1361,6 +1361,7 @@ mod tests {
         tracing::subscriber::set_default(subscriber)
     }
 
+    #[cfg(feature = "urispec")]
     #[tokio::test]
     async fn test_openconnectionarguments_try_from() {
         let args = OpenConnectionArguments::try_from("amqp://user:pass@host:10000/vhost").unwrap();

--- a/amqprs/src/api/error.rs
+++ b/amqprs/src/api/error.rs
@@ -9,6 +9,8 @@ use tokio::sync::{mpsc::error::SendError, oneshot::error::RecvError};
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// Error when creating arguments for opening a connection. Usually due to incorrect usage by user.
+    ConnectionOpenArgsError(String),
     /// Error during openning a connection.
     ConnectionOpenError(String),
     /// Error during closing a connection.
@@ -47,6 +49,9 @@ impl From<RecvError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Error::ConnectionOpenArgsError(msg) => {
+                write!(f, "AMQP connection open arguments error: {}", msg)
+            }
             Error::NetworkError(msg) => write!(f, "AMQP network error: {}", msg),
             Error::ConnectionOpenError(msg) => write!(f, "AMQP connection open error: {}", msg),
             Error::ConnectionCloseError(msg) => write!(f, "AMQP connection close error: {}", msg),

--- a/amqprs/src/lib.rs
+++ b/amqprs/src/lib.rs
@@ -18,7 +18,7 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! // Build arguments for new connection.
-//! let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
+//! let args = OpenConnectionArguments::new("localhost", 5672, "user", "bitnami");
 //! // Open an AMQP connection with given arguments.
 //! let connection = Connection::open(&args).await.unwrap();
 //!

--- a/amqprs/src/lib.rs
+++ b/amqprs/src/lib.rs
@@ -18,7 +18,7 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! // Build arguments for new connection.
-//! let args = OpenConnectionArguments::new("localhost:5672", "user", "bitnami");
+//! let args = OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami");
 //! // Open an AMQP connection with given arguments.
 //! let connection = Connection::open(&args).await.unwrap();
 //!

--- a/amqprs/tests/common/mod.rs
+++ b/amqprs/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub fn setup_logging(level: Level) -> DefaultGuard {
 
 #[cfg(not(feature = "tls"))]
 pub fn build_conn_args() -> OpenConnectionArguments {
-    OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
+    OpenConnectionArguments::new("localhost", 5672, "user", "bitnami")
 }
 #[cfg(feature = "tls")]
 pub fn build_conn_args() -> OpenConnectionArguments {
@@ -30,7 +30,7 @@ pub fn build_conn_args() -> OpenConnectionArguments {
     let client_private_key = current_dir.join("client_AMQPRS_TEST_key.pem");
     // domain should match the certificate/key files
     let domain = "AMQPRS_TEST";
-    OpenConnectionArguments::new("localhost", Some(5671), "user", "bitnami")
+    OpenConnectionArguments::new("localhost", 5671, "user", "bitnami")
         .tls_adaptor(
             amqprs::tls::TlsAdaptor::with_client_auth(
                 Some(root_ca_cert.as_path()),

--- a/amqprs/tests/common/mod.rs
+++ b/amqprs/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub fn setup_logging(level: Level) -> DefaultGuard {
 
 #[cfg(not(feature = "tls"))]
 pub fn build_conn_args() -> OpenConnectionArguments {
-    OpenConnectionArguments::new("localhost:5672", "user", "bitnami")
+    OpenConnectionArguments::new("localhost", Some(5672), "user", "bitnami")
 }
 #[cfg(feature = "tls")]
 pub fn build_conn_args() -> OpenConnectionArguments {
@@ -30,7 +30,7 @@ pub fn build_conn_args() -> OpenConnectionArguments {
     let client_private_key = current_dir.join("client_AMQPRS_TEST_key.pem");
     // domain should match the certificate/key files
     let domain = "AMQPRS_TEST";
-    OpenConnectionArguments::new("localhost:5671", "user", "bitnami")
+    OpenConnectionArguments::new("localhost", Some(5671), "user", "bitnami")
         .tls_adaptor(
             amqprs::tls::TlsAdaptor::with_client_auth(
                 Some(root_ca_cert.as_path()),


### PR DESCRIPTION
Here is an implementation that deprecates the previous `OpenConnnectionArguments::uri(uri: &str)` function. It changes `OpenConnectionArguments` to accept `host` and `port` rather than a uri with only host and port. Chainables for host and port added. Trait `TryFrom` implemented to support conversion from an `ampq(s)` uri to an `OpenConnectionArguments` object. Supports only one query parameter `heartbeat` with room to support more. I believe there are other query parameters used to help support `AMQPS` with TLS, but TLS was not hooked up in this PR, but I think this serves as a great basis to implement the AMQPS initialization from an amqps uri. 

This is in reference to issue #14, but does not fully address the TLS portion of the issue.