### PR TITLE
feat: return receiver on consume

### DIFF
--- a/amqprs/examples/basic_consumer.rs
+++ b/amqprs/examples/basic_consumer.rs
@@ -64,11 +64,9 @@ async fn main() {
         .no_ack(true)
         .finish();
 
-    channel
-        .basic_consume(DefaultConsumer::new(args.no_ack), args)
-        .await
-        .unwrap();
+    let mut messages_rx = channel.basic_consume(args).await.unwrap();
 
-    let guard = Notify::new();
-    guard.notified().await;
+    while let Some(_msg) = messages_rx.recv().await {
+        // do smthing with msg
+    }
 }

--- a/amqprs/examples/basic_consumer.rs
+++ b/amqprs/examples/basic_consumer.rs
@@ -64,9 +64,11 @@ async fn main() {
         .no_ack(true)
         .finish();
 
-    let mut messages_rx = channel.basic_consume(args).await.unwrap();
+    channel
+        .basic_consume(DefaultConsumer::new(args.no_ack), args)
+        .await
+        .unwrap();
 
-    while let Some(_msg) = messages_rx.recv().await {
-        // do smthing with msg
-    }
+    let guard = Notify::new();
+    guard.notified().await;
 }

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -519,8 +519,8 @@ impl Channel {
     ///
     /// let (ctag, mut messages_rx) = channel.basic_consume_rx(args).await.unwrap();
     ///
-    /// // you will need to run this in `tokio::spawn` if you want
-    /// // to do other things in parallel of message consumption
+    /// // you will need to run this in `tokio::spawn` or `tokio::task::spawn_blocking` 
+    /// // if you want to do other things in parallel of message consumption.
     /// while let Some(msg) = messages_rx.recv().await {
     ///     // do smthing with msg
     /// #   break;

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -455,8 +455,8 @@ impl Channel {
     /// If you were to stop consuming before the channel has been closed internally,
     /// you must call [`basic_cancel`] to make sure resources are cleaned up properly.
     ///
-    /// Also make sure that you call [`basic_qos`] before calling this method
-    /// to set a coherent value for your mspc channel's buffer.
+    /// It is recommended to call [`basic_qos`] before using this method as the underlying
+    /// message buffer is unbounded.
     ///
     /// ```
     /// # use amqprs::{

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -1,5 +1,5 @@
 use amqp_serde::types::AmqpDeliveryTag;
-use tokio::sync::mpsc::{self};
+use tokio::sync::mpsc;
 #[cfg(feature = "tracing")]
 use tracing::{debug, trace};
 

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -536,6 +536,8 @@ impl Channel {
     /// # Errors
     ///
     /// Returns an error if a failure occurs while comunicating with the server.
+    ///
+    /// [`basic_consume`]: struct.Channel.html#method.basic_consume
     pub async fn basic_consume_rx(
         &self,
         args: BasicConsumeArguments,

--- a/amqprs/src/api/channel/mod.rs
+++ b/amqprs/src/api/channel/mod.rs
@@ -44,7 +44,7 @@ use tracing::{debug, error, info};
 pub(crate) const CONSUMER_MESSAGE_BUFFER_SIZE: usize = 32;
 
 /// Aggregated buffer for a `deliver + content` sequence.
-pub(crate) struct ConsumerMessage {
+pub struct ConsumerMessage {
     deliver: Option<Deliver>,
     basic_properties: Option<BasicProperties>,
     content: Option<Vec<u8>>,

--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -37,7 +37,7 @@
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -875,6 +875,7 @@ impl Connection {
     pub fn is_open(&self) -> bool {
         self.shared.is_open.load(Ordering::Relaxed)
     }
+
     /// Returns interval of heartbeat in seconds.
     pub fn heartbeat(&self) -> u16 {
         self.shared.heartbeat
@@ -1003,8 +1004,10 @@ impl Connection {
         )?;
 
         // create channel instance
+        // set default prefetch count to 10
         let channel = Channel::new(
             AtomicBool::new(true),
+            AtomicU16::new(10),
             self.clone(),
             channel_id,
             self.shared.outgoing_tx.clone(),

--- a/amqprs/src/net/channel_manager.rs
+++ b/amqprs/src/net/channel_manager.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use amqp_serde::types::{AmqpChannelId, ShortUint};
-use tokio::sync::{mpsc::Sender, oneshot};
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 use crate::frame::MethodHeader;
 
@@ -14,11 +14,11 @@ pub(crate) struct ChannelResource {
 
     /// connection's default channel does not have dispatcher
     /// each channel has one and only one dispatcher
-    pub dispatcher: Option<Sender<IncomingMessage>>,
+    pub dispatcher: Option<UnboundedSender<IncomingMessage>>,
 }
 
 impl ChannelResource {
-    pub(crate) fn new(dispatcher: Option<Sender<IncomingMessage>>) -> Self {
+    pub(crate) fn new(dispatcher: Option<UnboundedSender<IncomingMessage>>) -> Self {
         Self {
             responders: HashMap::new(),
             dispatcher,
@@ -89,7 +89,10 @@ impl ChannelManager {
         self.resource.remove(channel_id)
     }
 
-    pub fn get_dispatcher(&self, channel_id: &AmqpChannelId) -> Option<&Sender<IncomingMessage>> {
+    pub fn get_dispatcher(
+        &self,
+        channel_id: &AmqpChannelId,
+    ) -> Option<&UnboundedSender<IncomingMessage>> {
         self.resource.get(channel_id)?.dispatcher.as_ref()
     }
 

--- a/amqprs/src/net/reader_handler.rs
+++ b/amqprs/src/net/reader_handler.rs
@@ -182,7 +182,7 @@ impl ReaderHandler {
                 let dispatcher = self.channel_manager.get_dispatcher(&channel_id);
                 match dispatcher {
                     Some(dispatcher) => {
-                        dispatcher.send(frame).await?;
+                        dispatcher.send(frame)?;
                         Ok(())
                     }
                     None => {

--- a/amqprs/tests/common/mod.rs
+++ b/amqprs/tests/common/mod.rs
@@ -1,5 +1,4 @@
 use amqprs::connection::OpenConnectionArguments;
-use tracing::{subscriber::DefaultGuard, Level};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 // construct a subscriber that prints formatted traces to stdout

--- a/amqprs/tests/test_callback.rs
+++ b/amqprs/tests/test_callback.rs
@@ -4,7 +4,6 @@ use amqprs::{
     connection::Connection,
 };
 
-use tracing::Level;
 mod common;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/amqprs/tests/test_consume.rs
+++ b/amqprs/tests/test_consume.rs
@@ -10,7 +10,6 @@ use amqprs::{
     BasicProperties, DELIVERY_MODE_TRANSIENT,
 };
 use tokio::time;
-use tracing::Level;
 mod common;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
@@ -122,6 +121,62 @@ async fn test_blocking_consumer() {
 
     // explicitly close
     pub_channel.close().await.unwrap();
+    consumer_channel.close().await.unwrap();
+    connection.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn test_consumer_rx() {
+    common::setup_logging();
+
+    // open a connection to RabbitMQ server
+    let args = common::build_conn_args();
+    let connection = Connection::open(&args).await.unwrap();
+
+    // open a channel dedicated for consumer on the connection
+    let consumer_channel = connection.open_channel(None).await.unwrap();
+
+    let exchange_name = "amq.topic";
+    // declare a queue
+    let (queue_name, ..) = consumer_channel
+        .queue_declare(QueueDeclareArguments::default())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // bind the queue to exchange
+    let routing_key = "amqprs_test_consumer_rx";
+    consumer_channel
+        .queue_bind(QueueBindArguments::new(
+            &queue_name,
+            exchange_name,
+            routing_key,
+        ))
+        .await
+        .unwrap();
+
+    // start blocking consumer
+    let args = BasicConsumeArguments::new(&queue_name, "amqprs_test_consumer_rx");
+
+    let (ctag, mut rx) = consumer_channel.basic_consume_rx(args).await.unwrap();
+
+    tokio::spawn(async move { while let Some(_msg) = rx.recv().await {} });
+
+    // open a channel dedicated for publisher on the connection
+    let pub_channel = connection.open_channel(None).await.unwrap();
+    // publish test messages
+    publish_test_messages(&pub_channel, exchange_name, routing_key, 5).await;
+
+    // keep the `channel` and `connection` object from dropping
+    // NOTE: channel/connection will be closed when drop
+    time::sleep(time::Duration::from_secs(1)).await;
+
+    // explicitly close
+    pub_channel.close().await.unwrap();
+    consumer_channel
+        .basic_cancel(BasicCancelArguments::new(&ctag))
+        .await
+        .unwrap();
     consumer_channel.close().await.unwrap();
     connection.close().await.unwrap();
 }

--- a/amqprs/tests/test_get.rs
+++ b/amqprs/tests/test_get.rs
@@ -6,7 +6,7 @@ use amqprs::{
     connection::Connection,
     BasicProperties,
 };
-use tracing::{info, Level};
+use tracing::info;
 mod common;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/amqprs/tests/test_heartbeat.rs
+++ b/amqprs/tests/test_heartbeat.rs
@@ -1,11 +1,11 @@
 use amqprs::{
     channel::{BasicConsumeArguments, QueueBindArguments, QueueDeclareArguments},
-    connection::{Connection, OpenConnectionArguments},
+    connection::Connection,
     consumer::DefaultConsumer,
 };
 
 use tokio::time;
-use tracing::{info, Level};
+use tracing::info;
 mod common;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/amqprs/tests/test_publish.rs
+++ b/amqprs/tests/test_publish.rs
@@ -5,7 +5,6 @@ use amqprs::{
     BasicProperties,
 };
 use tokio::time;
-use tracing::Level;
 mod common;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/amqprs/tests/test_publish_return.rs
+++ b/amqprs/tests/test_publish_return.rs
@@ -1,11 +1,10 @@
 use amqprs::{
     callbacks::{DefaultChannelCallback, DefaultConnectionCallback},
-    channel::{BasicPublishArguments, ExchangeDeclareArguments},
+    channel::BasicPublishArguments,
     connection::Connection,
     BasicProperties,
 };
 use tokio::time;
-use tracing::Level;
 mod common;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,15 @@ services:
     volumes:
       - "./rabbitmq_conf/custom.conf:/bitnami/rabbitmq/conf/custom.conf"
       - "./rabbitmq_conf/server:/bitnami/tls-test"
+      - rmq_data:/bitnami/rabbitmq
         
 networks:
   integration-net:
     driver: bridge
+
+volumes:
+  rmq_data:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: "size=35840m"


### PR DESCRIPTION
Hello, I was thinking about the consumer API of the library. I feel it'd be easier to just return the `tokio::mspc::Receiver` and let the client handle how they want to deal with consumption. whether it be in a separate thread or whatnot.

It'd make error handling easier too.

What do you think ? This PR is more of a demonstration of how I imagine it rather than something you might merge. Lmk if you want me to make this "prod ready", I can give it a shot.