### PR TITLE
reduce syscall by combing publish sequence into one write

### DIFF
--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -929,11 +929,6 @@ impl Channel {
         publish.set_mandatory(args.mandatory);
         publish.set_immediate(args.immediate);
 
-        self.shared
-            .outgoing_tx
-            .send((self.shared.channel_id, publish.into_frame()))
-            .await?;
-
         let content_header = ContentHeader::new(
             ContentHeaderCommon {
                 class: 60, // basic class
@@ -942,15 +937,12 @@ impl Channel {
             },
             basic_properties,
         );
-        self.shared
-            .outgoing_tx
-            .send((self.shared.channel_id, content_header.into_frame()))
-            .await?;
 
-        let content = ContentBody::new(content);
+        let publish_combo =
+            Frame::PublishCombo(publish, Box::new(content_header), ContentBody::new(content));
         self.shared
             .outgoing_tx
-            .send((self.shared.channel_id, content.into_frame()))
+            .send((self.shared.channel_id, publish_combo))
             .await?;
         Ok(())
     }

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -673,14 +673,13 @@ mod tests {
             None,
             Some("app".to_owned()),
             None,
-        );        
+        );
         assert_eq!([0x88, 0x88], props.property_flags);
 
         props.with_content_encoding("utf8");
         assert_eq!([0xC8, 0x88], props.property_flags);
-        
+
         props.with_timestamp(1674404425);
         assert_eq!([0xC8, 0xC8], props.property_flags);
-
     }
 }

--- a/amqprs/src/net/reader_handler.rs
+++ b/amqprs/src/net/reader_handler.rs
@@ -8,7 +8,7 @@ use tokio::{
     time,
 };
 #[cfg(feature = "traces")]
-use tracing::{debug, error, info, warn, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     api::{callbacks::ConnectionCallback, connection::Connection},

--- a/regression_test.sh
+++ b/regression_test.sh
@@ -2,25 +2,50 @@
 #// regression test before release
 set -x
 
+function check_result () {
+    ret=$?
+    if [[ $ret != 0 ]];then
+        echo "early exit due to error!"
+        exit $ret
+    fi
+}
+
 # all examples
 ./examples/run_examples.sh
+check_result
 
 # features combination
-cargo test 
+cargo test
+check_result
+
 cargo test -F traces
+check_result
+
 cargo test -F compliance_assert
+check_result
+
 cargo test -F tls
+check_result
+
 cargo test -F urispec
+check_result
+
 cargo test --all-features
+check_result
 
 # clippy, warnings not allowed
 cargo clippy --all-features -- -Dwarnings
+check_result
 
 # docs build
 cargo doc -p amqprs --all-features --open
+check_result
 
 # cargo msrv
 cargo msrv
+check_result
 
 # dry-run publish
 cargo publish -p amqprs --all-features --dry-run
+check_result
+


### PR DESCRIPTION
according to the AMQP protocol, publish content is done in 3 frames: **Publish + Header + Body**. Current implementation make one write per frame. This is to make one write for all 3 frames of a publish so that reducing syscalls.