### PR TITLE
feat(api): make connection err msg more explicit

### DIFF
--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -584,7 +584,7 @@ impl Connection {
         unwrap_expected_method!(
             frame,
             Frame::OpenOk,
-            Error::ConnectionOpenError("open".to_string())
+            Error::ConnectionOpenError(format!("failed to open connection, reason: {frame}"))
         )?;
 
         // spawn network management tasks and get internal channel' sender half.

--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -584,7 +584,7 @@ impl Connection {
         unwrap_expected_method!(
             frame,
             Frame::OpenOk,
-            Error::ConnectionOpenError(format!("failed to open connection, reason: {frame}"))
+            Error::ConnectionOpenError(format!("failed to open connection, reason: {}", frame))
         )?;
 
         // spawn network management tasks and get internal channel' sender half.
@@ -664,7 +664,10 @@ impl Connection {
         let mut start = unwrap_expected_method!(
             frame,
             Frame::Start,
-            Error::ConnectionOpenError("start".to_string())
+            Error::ConnectionOpenError(format!(
+                "failed to negotiate connection params, reason: {}",
+                frame
+            ))
         )?;
         // get server supported locales
         if !start
@@ -769,7 +772,10 @@ impl Connection {
         let tune = unwrap_expected_method!(
             frame,
             Frame::Tune,
-            Error::ConnectionOpenError("tune".to_string())
+            Error::ConnectionOpenError(format!(
+                "failed to tune connection params, reason: {}",
+                frame
+            ))
         )?;
 
         // according to https://www.rabbitmq.com/heartbeats.html


### PR DESCRIPTION
I was having a hard debugging a connection error, I think it would be nice to have frame info in err message.

This is just a first step, there may be a cleaner way to extract the `reply_text` of the `Close` frame (not sure which frames can be received on connection error, so it was easier to just dump the whole frame for the moment).

Happy to edit the code if you know what types of Frames I should handle.