### PR TITLE
Fix: prevent "attempt to subtract with overflow" when channel_max=0

### DIFF
--- a/amqprs/src/net/channel_id_repo.rs
+++ b/amqprs/src/net/channel_id_repo.rs
@@ -9,7 +9,7 @@ pub(crate) struct ChannelIdRepository {
 impl ChannelIdRepository {
     pub fn new(channel_max: ShortUint) -> Self {
         let len = match channel_max {
-            0 => u16::MAX as usize,
+            0 => 1 + (u16::MAX as usize - 1) / 8,
             max => 1 + (max as usize - 1) / 8,
         };
 

--- a/amqprs/src/net/channel_id_repo.rs
+++ b/amqprs/src/net/channel_id_repo.rs
@@ -8,7 +8,10 @@ pub(crate) struct ChannelIdRepository {
 }
 impl ChannelIdRepository {
     pub fn new(channel_max: ShortUint) -> Self {
-        let len = 1 + (channel_max as usize - 1) / 8;
+        let len = match channel_max {
+            0 => u16::MAX as usize,
+            max => 1 + (max as usize - 1) / 8,
+        };
 
         Self {
             id_state: vec![0; len],
@@ -148,6 +151,32 @@ mod tests {
         // failed to reserve
         for id in ids {
             assert_eq!(false, id_repo.reserve(id));
+        }
+    }
+
+    #[test]
+    fn test_id_allocate_and_release_with_channel_max_zero() {
+        let channel_max = 0;
+        let mut id_repo = ChannelIdRepository::new(channel_max);
+
+        let mut ids = HashSet::new();
+        // allocate to max
+        for _ in 0..channel_max {
+            let id = id_repo.allocate();
+            // id should be unique
+            assert_eq!(true, ids.insert(id));
+        }
+        // free all
+        for id in ids {
+            assert_eq!(true, id_repo.release(id));
+        }
+        //can allocte to max again
+        let mut ids = HashSet::new();
+
+        for _ in 0..channel_max {
+            let id = id_repo.allocate();
+            // id should be unique
+            assert_eq!(true, ids.insert(id));
         }
     }
 }

--- a/amqprs/src/net/channel_id_repo.rs
+++ b/amqprs/src/net/channel_id_repo.rs
@@ -173,7 +173,7 @@ mod tests {
         //can allocte to max again
         let mut ids = HashSet::new();
 
-        for _ in 0..channel_max {
+        for _ in 0..u16::MAX {
             let id = id_repo.allocate();
             // id should be unique
             assert_eq!(true, ids.insert(id));

--- a/amqprs/src/net/channel_id_repo.rs
+++ b/amqprs/src/net/channel_id_repo.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let mut ids = HashSet::new();
         // allocate to max
-        for _ in 0..channel_max {
+        for _ in 0..u16::MAX {
             let id = id_repo.allocate();
             // id should be unique
             assert_eq!(true, ids.insert(id));


### PR DESCRIPTION
Fix an issue causing a panic with `attempt to subtract with overflow` when trying to connect to an amqp host configured to have channel_max=0

This is the default value in https://www.cloudamqp.com/ and means "unlimited"

When built with the --release flag it won't panic when subtracting with overflow, but will instead panic with
```memory allocation of 2305843009213693952 bytes failed```