### PR TITLE
basic.consume args: alias no_ack

### DIFF
--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -524,7 +524,7 @@ impl Channel {
     /// #     .await
     /// #     .unwrap();
     /// let args = BasicConsumeArguments::new(&queue_name, "basic_consumer")
-    ///     .no_ack(true)
+    ///     .manual_ack(false)
     ///     .finish();
     ///
     /// let (ctag, mut messages_rx) = channel.basic_consume_rx(args).await.unwrap();
@@ -1002,7 +1002,7 @@ mod tests {
                 .unwrap();
 
             let args = BasicConsumeArguments::new(&queue_name, "test_auto_ack")
-                .no_ack(true)
+                .auto_ack(true)
                 .finish();
 
             channel

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -72,8 +72,8 @@ impl BasicQosArguments {
 /// # use amqprs::channel::BasicConsumeArguments;
 ///
 /// let x = BasicConsumeArguments::new("q", "c")
-///     .no_ack(true)
-///     .exclusive(true)
+///     .manual_ack(true)
+///     .exclusive(false)
 ///     .finish();
 /// ```
 ///
@@ -82,15 +82,15 @@ impl BasicQosArguments {
 /// [`basic_consume`]: struct.Channel.html#method.basic_consume
 #[derive(Debug, Clone, Default)]
 pub struct BasicConsumeArguments {
-    /// Queue Name. Default: "".
+    /// Target queue name. Must be provided.
     pub queue: String,
-    /// Default: "".
+    /// Consumer identifier. Default: "" (server-generated).
     pub consumer_tag: String,
-    /// Default: `false`.
+    /// Ignored by modern RabbitMQ releases. Default: `false`.
     pub no_local: bool,
-    /// Default: `false`.
+    /// Should automatic acknowedgements be used? Default: `false`.
     pub no_ack: bool,
-    /// Default: `false`.
+    /// Should this consumer be exclusive (the only one allowed on the target queue)? Default: `false`.
     pub exclusive: bool,
     /// Default: `false`.
     pub no_wait: bool,
@@ -125,6 +125,14 @@ impl BasicConsumeArguments {
     impl_chainable_setter! {
         /// Chainable setter method.
         no_local, bool
+    }
+    impl_chainable_alias_setter! {
+        /// Chainable setter method.
+        auto_ack, no_ack, bool
+    }
+    pub fn manual_ack(&mut self, value: bool) -> &mut Self {
+        self.no_ack = !value;
+        self
     }
     impl_chainable_setter! {
         /// Chainable setter method.

--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -88,7 +88,7 @@ pub struct BasicConsumeArguments {
     pub consumer_tag: String,
     /// Ignored by modern RabbitMQ releases. Default: `false`.
     pub no_local: bool,
-    /// Should automatic acknowedgements be used? Default: `false`.
+    /// Should automatic acknowledgements be used? Default: `false`.
     pub no_ack: bool,
     /// Should this consumer be exclusive (the only one allowed on the target queue)? Default: `false`.
     pub exclusive: bool,
@@ -136,6 +136,7 @@ impl BasicConsumeArguments {
     }
     impl_chainable_setter! {
         /// Chainable setter method.
+        #[deprecated(since="1.2.0", note="use the manual_ack builder method")]
         no_ack, bool
     }
 
@@ -923,7 +924,8 @@ impl Channel {
     ///
     /// # Errors
     ///
-    /// Returns error if any failure in comunication with server.
+    /// Returns error in case of a network I/O failure. For data safety, use
+    /// [publisher confirms](https://rabbitmq.com/publishers.html#data-safety).
     pub async fn basic_publish(
         &self,
         basic_properties: BasicProperties,

--- a/amqprs/src/api/mod.rs
+++ b/amqprs/src/api/mod.rs
@@ -37,6 +37,17 @@ pub(crate) mod helpers {
         };
     }
 
+    macro_rules! impl_chainable_alias_setter {
+        ($(#[$($attrss:tt)*])* $method_name:ident, $field_name:ident, $input_type:ty) => {
+            $(#[$($attrss)*])*
+            pub fn $method_name(&mut self, $field_name: $input_type) -> &mut Self {
+                self.$field_name = $field_name;
+                self
+            }
+
+        };
+    }
+
     // pub(crate) use impl_chainable_setter;
 }
 

--- a/amqprs/tests/test_mixed_type_consumers.rs
+++ b/amqprs/tests/test_mixed_type_consumers.rs
@@ -12,12 +12,12 @@ use tokio::time;
 mod common;
 
 struct MixedConsumer {
-    no_ack: bool,
+    auto_ack: bool,
 }
 
 impl MixedConsumer {
-    pub fn new(no_ack: bool) -> Self {
-        Self { no_ack }
+    pub fn new(auto_ack: bool) -> Self {
+        Self { auto_ack }
     }
 }
 
@@ -36,7 +36,7 @@ impl AsyncConsumer for MixedConsumer {
             channel
         );
         // ack explicitly if manual ack
-        if !self.no_ack {
+        if !self.auto_ack {
             let tag = deliver.delivery_tag();
             let prio = basic_properties.priority().unwrap_or_else(|| 0);
             if prio <= 1 {
@@ -84,7 +84,7 @@ impl BlockingConsumer for MixedConsumer {
         );
 
         // ack explicitly if manual ack
-        if !self.no_ack {
+        if !self.auto_ack {
             let tag = deliver.delivery_tag();
             let prio = basic_properties.priority().unwrap_or_else(|| 0);
             if prio <= 1 {

--- a/examples/src/longlive_basic_consumer.rs
+++ b/examples/src/longlive_basic_consumer.rs
@@ -61,7 +61,7 @@ async fn main() {
     //////////////////////////////////////////////////////////////////////////////
     // start consumer, auto ack
     let args = BasicConsumeArguments::new(&queue_name, "basic_consumer")
-        .no_ack(true)
+        .manual_ack(false)
         .finish();
 
     channel


### PR DESCRIPTION
Other clients typically use "manual_ack" as a more descriptive name, although auto_ack also works well, and is an alias for "no_ack" (the protocol field).

Closes #83