### PR TITLE
Introduce BasicProperties::with_persistence

### DIFF
--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -1068,7 +1068,7 @@ mod tests {
 
             let basic_properties = BasicProperties::default()
                 .with_content_type("application/json;charset=utf-8")
-                .with_delivery_mode(DELIVERY_MODE_TRANSIENT)
+                .with_persistence(true)
                 .finish();
 
             let content = String::from(

--- a/amqprs/src/api/channel/confim.rs
+++ b/amqprs/src/api/channel/confim.rs
@@ -96,7 +96,7 @@ mod tests {
         let args = BasicPublishArguments::new("amq.topic", "amqprs.test.transaction");
 
         let basic_properties = BasicProperties::default()
-            .with_delivery_mode(DELIVERY_MODE_TRANSIENT)
+            .with_persistence(true)
             .finish();
 
         let content = String::from("AMQPRS test publish confirm").into_bytes();

--- a/amqprs/src/api/channel/tx.rs
+++ b/amqprs/src/api/channel/tx.rs
@@ -121,7 +121,7 @@ mod tests {
         let args = BasicPublishArguments::new("amq.topic", "amqprs.test.transaction");
 
         let basic_properties = BasicProperties::default()
-            .with_delivery_mode(DELIVERY_MODE_TRANSIENT)
+            .with_persistence(true)
             .finish();
 
         let content = String::from("AMQPRS test transactions").into_bytes();

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -331,11 +331,12 @@ impl BasicProperties {
     /// # Example
     ///
     /// ```
-    /// # use amqprs::BasicProperties;
-    /// let prop1 = BasicProperties::default()
+    /// use amqprs::BasicProperties;
+    /// use amqprs::{DELIVERY_MODE_PERSISTENT, DELIVERY_MODE_TRANSIENT};
+    /// let mut prop1 = BasicProperties::default()
     ///     .with_persistence(true)
     ///     .finish();
-    /// let prop2 = BasicProperties::default().
+    /// let mut prop2 = BasicProperties::default()
     ///     .with_delivery_mode(DELIVERY_MODE_PERSISTENT)
     ///     .finish();
     /// assert_eq!(prop1.delivery_mode(), prop2.delivery_mode());

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -46,9 +46,9 @@ pub struct ContentHeaderCommon {
 /// # use amqprs::{BasicProperties, DELIVERY_MODE_PERSISTENT};
 /// let basic_props = BasicProperties::default()
 ///     .with_content_type("application/json")
-///     .with_delivery_mode(DELIVERY_MODE_PERSISTENT)
-///     .with_user_id("user")
-///     .with_app_id("consumer_test")
+///     .with_persistence(true)
+///     .with_message_type("app1.notifications.orders.created")
+///     .with_app_id("app1")
 ///     .finish();
 /// ```
 #[derive(Debug, Serialize, Default, Clone)]
@@ -299,7 +299,7 @@ impl BasicProperties {
         self.delivery_mode
     }
 
-    /// Chainable setter of delivery mode.
+    /// Chainable setter of delivery mode. Prefer `with_persistence` as it is more to the point.
     ///
     /// `delivery_mode`: either [`DELIVERY_MODE_TRANSIENT`] or [`DELIVERY_MODE_PERSISTENT`]
     ///
@@ -307,16 +307,35 @@ impl BasicProperties {
     ///
     /// [`DELIVERY_MODE_TRANSIENT`]: ../constant.DELIVERY_MODE_TRANSIENT.html
     /// [`DELIVERY_MODE_PERSISTENT`]: ../constant.DELIVERY_MODE_PERSISTENT.html
+    ///
+    /// # Example
+    /// ```
+    /// # use amqprs::{BasicProperties, DELIVERY_MODE_PERSISTENT};
+    /// let basic_props = BasicProperties::default()
+    ///     .with_content_type("application/json")
+    ///     .with_delivery_mode(DELIVERY_MODE_PERSISTENT)
+    ///     .finish();
+    /// ```
     pub fn with_delivery_mode(&mut self, delivery_mode: u8) -> &mut Self {
         Self::set_delivery_mode_flag(&mut self.property_flags);
         self.delivery_mode = Some(delivery_mode);
         self
     }
 
-    /// Sets delivery mode using a boolean.
+    /// Marks a message as persistent (or not) using a boolean. When in doubt, prefer
+    /// publishing messages as persistent.
     ///
     /// `persistent`: true for persistent delivery mode (2), false for transient (1)
     ///
+    /// # Example
+    ///
+    /// ```
+    /// # use amqprs::BasicProperties;
+    /// let basic_props = BasicProperties::default()
+    ///     .with_content_type("application/json")
+    ///     .with_persistence(true)
+    ///     .finish();
+    /// ```
     pub fn with_persistence(&mut self, persistent: bool) -> &mut Self {
         let delivery_mode = if persistent {
             DELIVERY_MODE_PERSISTENT

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -332,10 +332,16 @@ impl BasicProperties {
     ///
     /// ```
     /// # use amqprs::BasicProperties;
-    /// let basic_props = BasicProperties::default()
-    ///     .with_content_type("application/json")
+    /// let prop1 = BasicProperties::default()
     ///     .with_persistence(true)
     ///     .finish();
+    /// let prop2 = BasicProperties::default().
+    ///     .with_delivery_mode(DELIVERY_MODE_PERSISTENT)
+    ///     .finish();
+    /// assert_eq!(prop1.delivery_mode(), prop2.delivery_mode());
+    /// prop1.with_persistence(false);
+    /// prop2.with_delivery_mode(DELIVERY_MODE_TRANSIENT);
+    /// assert_eq!(prop1.delivery_mode(), prop2.delivery_mode());
     /// ```
     pub fn with_persistence(&mut self, persistent: bool) -> &mut Self {
         let delivery_mode = if persistent {

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -326,7 +326,8 @@ impl BasicProperties {
     /// publishing messages as persistent.
     ///
     /// `persistent`: true for persistent delivery mode (2), false for transient (1)
-    ///
+    /// `with_persistence(true)` is equivalent to `with_delivery_mode(DELIVERY_MODE_PERSISTENT)`.
+    /// `with_persistence(false)` is equivalent to `with_delivery_mode(DELIVERY_MODE_TRANSIENT)`.
     /// # Example
     ///
     /// ```

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use amqp_serde::types::{FieldTable, LongLongUint, Octect, ShortStr, ShortUint, TimeStamp};
 use serde::{de::Visitor, Deserialize, Serialize};
+use crate::{DELIVERY_MODE_PERSISTENT, DELIVERY_MODE_TRANSIENT};
 
 use super::Frame;
 
@@ -307,6 +308,21 @@ impl BasicProperties {
     /// [`DELIVERY_MODE_TRANSIENT`]: ../constant.DELIVERY_MODE_TRANSIENT.html
     /// [`DELIVERY_MODE_PERSISTENT`]: ../constant.DELIVERY_MODE_PERSISTENT.html
     pub fn with_delivery_mode(&mut self, delivery_mode: u8) -> &mut Self {
+        Self::set_delivery_mode_flag(&mut self.property_flags);
+        self.delivery_mode = Some(delivery_mode);
+        self
+    }
+
+    /// Sets delivery mode using a boolean.
+    ///
+    /// `persistent`: true for persistent delivery mode (2), false for transient (1)
+    ///
+    pub fn with_persistence(&mut self, persistent: bool) -> &mut Self {
+        let delivery_mode = if persistent {
+            DELIVERY_MODE_PERSISTENT
+        } else {
+            DELIVERY_MODE_TRANSIENT
+        };
         Self::set_delivery_mode_flag(&mut self.property_flags);
         self.delivery_mode = Some(delivery_mode);
         self

--- a/amqprs/tests/test_consume.rs
+++ b/amqprs/tests/test_consume.rs
@@ -362,7 +362,7 @@ async fn publish_test_messages(
     let basic_props = BasicProperties::default()
         .with_content_type("application/json")
         .with_headers(headers)
-        .with_delivery_mode(DELIVERY_MODE_TRANSIENT)
+        .with_persistence(true)
         .with_user_id("user")
         .with_app_id("consumer_test")
         .finish();


### PR DESCRIPTION
as a more human-friendly alternative to
`BasicProperties::set_delivery_mode`.

Closes #80.