### PR TITLE
FieldValue TryInto for string-like types.

### DIFF
--- a/amqp_serde/src/types.rs
+++ b/amqp_serde/src/types.rs
@@ -351,6 +351,40 @@ impl TryInto<LongStr> for FieldValue {
     }
 }
 
+impl<'a> TryInto<&'a LongStr> for &'a FieldValue {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<&'a LongStr, Self::Error> {
+        match self {
+            FieldValue::S(v) => Ok(v),
+            _ => Err(crate::Error::Message("not a LongStr".to_string())),
+        }
+    }
+}
+
+impl<'a> TryInto<&'a String> for &'a FieldValue {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<&'a String, Self::Error> {
+        match self {
+            FieldValue::S(v) => Ok(v.as_ref()),
+            _ => Err(crate::Error::Message("not a LongStr".to_string())),
+        }
+    }
+}
+
+impl<'a> TryInto<&'a str> for &'a FieldValue {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<&'a str, Self::Error> {
+        match self {
+            FieldValue::S(v) => Ok(v.as_ref()),
+            _ => Err(crate::Error::Message("not a LongStr".to_string())),
+        }
+    }
+}
+
+
 /// RabbitMQ's field value support only long string variant, so rust string type
 /// always converted to long string variant.
 impl From<String> for FieldValue {

--- a/amqp_serde/src/types.rs
+++ b/amqp_serde/src/types.rs
@@ -671,6 +671,21 @@ mod tests {
     }
 
     #[test]
+    fn test_field_value_try_into_strings() {
+        let test_str = "test_string";
+        let test_string = String::from(test_str);
+        let test_longstr = LongStr::try_from(test_str).unwrap();
+        let exp = FieldValue::S(test_longstr.clone());
+        let exp_ref = &exp;
+        let extracted_str: &str = exp_ref.try_into().unwrap();
+        let extracted_longstr: &LongStr = exp_ref.try_into().unwrap();
+        let extracted_string: &String = exp_ref.try_into().unwrap();
+        assert_eq!(test_str, extracted_str);
+        assert_eq!(test_string, *extracted_string);
+        assert_eq!(test_longstr, *extracted_longstr);
+    }
+
+    #[test]
     fn test_len_for_field_value_of_type_field_array() {
         let s1: LongStr = "1".try_into().unwrap();
         let s2: LongStr = "2".try_into().unwrap();

--- a/amqp_serde/src/types.rs
+++ b/amqp_serde/src/types.rs
@@ -681,8 +681,8 @@ mod tests {
         let extracted_longstr: &LongStr = exp_ref.try_into().unwrap();
         let extracted_string: &String = exp_ref.try_into().unwrap();
         assert_eq!(test_str, extracted_str);
-        assert_eq!(test_string, *extracted_string);
-        assert_eq!(test_longstr, *extracted_longstr);
+        assert_eq!(&test_string, extracted_string);
+        assert_eq!(&test_longstr, extracted_longstr);
     }
 
     #[test]


### PR DESCRIPTION
Here are the three additional variants of `TryInto` for `&FieldValue`. To `&LongStr`, `&String` and `&str`.

They corresponds to three variants of From trait: there are also `LongStr`, `String` and `&str`.

These three variants try to convert a reference to `FieldValue` to the reference on internal data without creating additional copies.

