### PR TITLE
Fix parsing amqps URL without query params

### DIFF
--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -1507,6 +1507,18 @@ mod tests {
     }
 
     #[cfg(all(feature = "urispec", feature = "tls"))]
+    #[test]
+    fn test_urispec_amqps_simple() {
+        let args = OpenConnectionArguments::try_from("amqps://localhost")
+            .unwrap();
+        assert_eq!(args.host, "localhost");
+        assert_eq!(args.port, 5671);
+        assert_eq!(args.virtual_host, "/");
+        let tls_adaptor = args.tls_adaptor.unwrap();
+        assert_eq!(tls_adaptor.domain, "localhost");
+    }
+
+    #[cfg(all(feature = "urispec", feature = "tls"))]
     #[tokio::test]
     #[should_panic(expected = "UriError")]
     async fn test_amqp_scheme_with_tls() {


### PR DESCRIPTION
The implementation in https://github.com/gftea/amqprs/pull/121 missed an early return statement, meaning that the TLS adaptor was only applied if there were no query parameters in the URL.