### PR TITLE
Add update-secret to the connection

### DIFF
--- a/amqprs/src/api/callbacks.rs
+++ b/amqprs/src/api/callbacks.rs
@@ -54,6 +54,9 @@ pub trait ConnectionCallback {
 
     /// Callback to handle connection `unblocked` indication from server
     async fn unblocked(&mut self, connection: &Connection);
+
+    /// Callback to handle secret updated indication from server
+    async fn secret_updated(&mut self, connection: &Connection);
 }
 
 /// Default type that implements `ConnectionCallback`.
@@ -84,6 +87,14 @@ impl ConnectionCallback for DefaultConnectionCallback {
         #[cfg(feature = "traces")]
         info!(
             "handle unblocked notification for connection {}",
+            connection
+        );
+    }
+
+    async fn secret_updated(&mut self, connection: &Connection) {
+        #[cfg(feature = "traces")]
+        info!(
+            "handle secret updated notification for connection {}",
             connection
         );
     }

--- a/amqprs/src/api/error.rs
+++ b/amqprs/src/api/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     /// Error in sending or receiving messages via internal communication channel.
     /// Usually due to incorrect usage by user.
     InternalChannelError(String),
+    /// Error during updating the secret
+    UpdateSecretError(String),
 }
 
 #[cfg(feature = "urispec")]
@@ -71,6 +73,7 @@ impl fmt::Display for Error {
             Error::InternalChannelError(msg) => {
                 write!(f, "AMQP internal communication error: {}", msg)
             }
+            Error::UpdateSecretError(msg) => write!(f, "AMQP update secret error: {}", msg),
         }
     }
 }

--- a/amqprs/src/frame/method/connection.rs
+++ b/amqprs/src/frame/method/connection.rs
@@ -219,5 +219,11 @@ pub struct UpdateSecret {
     pub(crate) reason: ShortStr,
 }
 
+impl UpdateSecret {
+    pub fn new(new_secret: LongStr, reason: ShortStr) -> Self {
+        Self { new_secret, reason }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct UpdateSecretOk;

--- a/amqprs/src/net/reader_handler.rs
+++ b/amqprs/src/net/reader_handler.rs
@@ -190,6 +190,20 @@ impl ReaderHandler {
                 }
                 Ok(())
             }
+            Frame::UpdateSecretOk(method_header, update_secret_ok) => {
+                let responder = self
+                    .channel_manager
+                    .remove_responder(&channel_id, method_header)
+                    .expect("responder must be registered");
+                responder
+                    .send(update_secret_ok.into_frame())
+                    .map_err(|err_frame| {
+                        Error::SyncChannel(format!(
+                            "failed to forward {} to connection {}",
+                            err_frame, self.amqp_connection
+                        ))
+                    })
+            }
             // dispatch other frames to channel dispatcher
             _ => {
                 let dispatcher = self.channel_manager.get_dispatcher(&channel_id);

--- a/amqprs/tests/test_update_secret.rs
+++ b/amqprs/tests/test_update_secret.rs
@@ -1,0 +1,34 @@
+use amqprs::{
+    callbacks::{DefaultChannelCallback, DefaultConnectionCallback},
+    connection::Connection,
+};
+mod common;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_update_secret() {
+    common::setup_logging();
+
+    // open a connection to RabbitMQ server
+    let args = common::build_conn_args();
+
+    let connection = Connection::open(&args).await.unwrap();
+    connection
+        .register_callback(DefaultConnectionCallback)
+        .await
+        .unwrap();
+    // open a channel on the connection
+    let channel = connection.open_channel(None).await.unwrap();
+    channel
+        .register_callback(DefaultChannelCallback)
+        .await
+        .unwrap();
+
+    connection
+        .update_secret("123456", "secret expired")
+        .await
+        .unwrap();
+
+    // close
+    channel.close().await.unwrap();
+    connection.close().await.unwrap();
+}

--- a/examples/src/callbacks_impl.rs
+++ b/examples/src/callbacks_impl.rs
@@ -23,6 +23,7 @@ impl ConnectionCallback for ExampleConnectionCallback {
 
     async fn blocked(&mut self, connection: &Connection, reason: String) {}
     async fn unblocked(&mut self, connection: &Connection) {}
+    async fn secret_updated(&mut self, connection: &Connection) {}
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The rabbitmq spec allow a [secret-update](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/b8e975a762b8677263ebbbba1e70654b5263af81/docs/amqp-0-9-1-reference.md#--------update-secret------------------------------------longstrnew-secret----------------------------------------------------shortstrreason------------------------update-secret-ok------------) message to update secrets that have an expiration date. This pr adds to the connection object the method to send the secret update message.

One more function had to be added to the ConnectionCallback making this a breaking change.