### PR TITLE
Docs: replace AMQP 0-9-1 reference links

### DIFF
--- a/amqprs/src/api/channel/basic.rs
+++ b/amqprs/src/api/channel/basic.rs
@@ -25,7 +25,7 @@ use super::{Channel, DeregisterContentConsumer, RegisterGetContentResponder};
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_qos`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.qos).
 ///
 /// [`basic_qos`]: struct.Channel.html#method.basic_qos
 #[derive(Debug, Clone, Default)]
@@ -77,7 +77,7 @@ impl BasicQosArguments {
 ///     .finish();
 /// ```
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.consume).
 ///
 /// [`basic_consume`]: struct.Channel.html#method.basic_consume
 #[derive(Debug, Clone, Default)]
@@ -166,7 +166,7 @@ impl BasicConsumeArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_cancel`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.cancel).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.cancel).
 ///
 /// [`basic_cancel`]: struct.Channel.html#method.basic_cancel
 #[derive(Debug, Clone, Default)]
@@ -201,7 +201,7 @@ impl BasicCancelArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_get`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.get).
 ///
 /// [`basic_get`]: struct.Channel.html#method.basic_get
 #[derive(Debug, Clone, Default)]
@@ -250,7 +250,7 @@ pub type GetMessage = (GetOk, BasicProperties, Vec<u8>);
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_ack`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.ack).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.ack).
 ///
 /// [`basic_ack`]: struct.Channel.html#method.basic_ack
 #[derive(Debug, Clone, Default)]
@@ -273,7 +273,7 @@ impl BasicAckArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_nack`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.nack).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.nack).
 ///
 /// [`basic_nack`]: struct.Channel.html#method.basic_nack
 #[derive(Debug, Clone)]
@@ -307,7 +307,7 @@ impl BasicNackArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_reject`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.reject).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.reject).
 ///
 /// [`basic_reject`]: struct.Channel.html#method.basic_reject
 #[derive(Debug, Clone)]
@@ -338,7 +338,7 @@ impl BasicRejectArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`basic_publish`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.publish).
 ///
 /// [`basic_publish`]: struct.Channel.html#method.basic_publish
 #[derive(Debug, Clone, Default)]
@@ -394,7 +394,7 @@ impl BasicPublishArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// APIs for AMQP basic class.
 impl Channel {
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.qos)
     ///
     /// # Errors
     ///
@@ -413,7 +413,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.consume)
     ///
     /// Returns the consumer tag on success.
     ///
@@ -716,7 +716,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.ack)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.ack)
     ///
     /// # Errors
     ///
@@ -749,7 +749,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.nack)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.nack)
     ///
     /// # Errors
     ///
@@ -786,7 +786,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.reject)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.reject)
     ///
     /// # Errors
     ///
@@ -813,7 +813,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.cancel)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.cancel)
     ///
     /// Returns consumer tag if succeed.
     ///
@@ -855,7 +855,7 @@ impl Channel {
         Ok(consumer_tag2)
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.get)
     ///
     /// Either returns a tuple [`GetMessage`] or [`None`] if no message available.
     ///
@@ -899,7 +899,7 @@ impl Channel {
         Ok(Some((get_ok, basic_properties, content)))
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.recover)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.recover)
     ///
     /// # Errors
     ///
@@ -919,7 +919,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.publish)
     ///
     /// # Errors
     ///

--- a/amqprs/src/api/channel/confim.rs
+++ b/amqprs/src/api/channel/confim.rs
@@ -7,7 +7,7 @@ use super::{Channel, Result};
 
 /// Arguments for [`confirm_select`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#confirm.select).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#confirm.select).
 ///
 /// [`confirm_select`]: struct.Channel.html#method.confirm_select
 #[derive(Debug, Clone, Default)]
@@ -25,7 +25,7 @@ impl ConfirmSelectArguments {
 
 /// APIs for AMQP confirm class.
 impl Channel {
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#confirm.select).
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#confirm.select).
     ///
     /// # Errors
     ///

--- a/amqprs/src/api/channel/exchange.rs
+++ b/amqprs/src/api/channel/exchange.rs
@@ -113,7 +113,7 @@ impl Display for ExchangeType {
 ///     .durable(true)
 ///     .finish();
 /// ```
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.declare).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.declare).
 ///
 /// [`exchange_declare`]: struct.Channel.html#method.exchange_declare
 #[derive(Debug, Clone)]
@@ -218,7 +218,7 @@ impl ExchangeDeclareArguments {
 
 /// Arguments for [`exchange_delete`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.delete).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.delete).
 ///
 /// [`exchange_delete`]: struct.Channel.html#method.exchange_delete
 #[derive(Debug, Clone, Default)]
@@ -266,7 +266,7 @@ impl ExchangeDeleteArguments {
 
 /// Arguments for [`exchange_bind`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.bind).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.bind).
 ///
 /// [`exchange_bind`]: struct.Channel.html#method.exchange_bind
 #[derive(Debug, Clone, Default)]
@@ -332,7 +332,7 @@ impl ExchangeBindArguments {
 
 /// Arguments for [`exchange_unbind`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.unbind).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.unbind).
 ///
 /// [`exchange_unbind`]: struct.Channel.html#method.exchange_unbind
 #[derive(Debug, Clone, Default)]
@@ -398,7 +398,7 @@ impl ExchangeUnbindArguments {
 /////////////////////////////////////////////////////////////////////////////
 /// APIs for AMQP exchange class
 impl Channel {
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.declaure)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.declaure)
     ///
     /// # Errors
     ///
@@ -436,7 +436,7 @@ impl Channel {
             Ok(())
         }
     }
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.delete)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.delete)
     ///
     /// # Errors
     ///
@@ -464,7 +464,7 @@ impl Channel {
             Ok(())
         }
     }
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.bind)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.bind)
     ///
     /// # Errors
     ///
@@ -497,7 +497,7 @@ impl Channel {
             Ok(())
         }
     }
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.unbind)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#exchange.unbind)
     ///
     /// # Errors
     ///

--- a/amqprs/src/api/channel/mod.rs
+++ b/amqprs/src/api/channel/mod.rs
@@ -285,7 +285,7 @@ impl Channel {
     /// Asks the server to pause or restart the flow of content data.
     ///
     /// Ask to start the flow if input `active` = `true`, otherwise to pause.
-    /// Also see [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow).
+    /// Also see [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#channel.flow).
     ///
     /// Returns `true` means the server will start/continue the flow, otherwise it will not.
     ///

--- a/amqprs/src/api/channel/queue.rs
+++ b/amqprs/src/api/channel/queue.rs
@@ -25,7 +25,7 @@ use crate::api::compliance_asserts::{assert_exchange_name, assert_queue_name};
 ///     .finish();
 /// ```
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.declare).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.declare).
 ///
 /// [`queue_declare`]: struct.Channel.html#method.queue_declare
 #[derive(Debug, Clone, Default)]
@@ -149,7 +149,7 @@ impl QueueDeclareArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`queue_bind`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.bind).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.bind).
 ///
 /// [`queue_bind`]: struct.Channel.html#method.queue_bind
 #[derive(Debug, Clone, Default)]
@@ -218,7 +218,7 @@ impl QueueBindArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`queue_purge`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.purge).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.purge).
 ///
 /// [`queue_purge`]: struct.Channel.html#method.queue_purge
 #[derive(Debug, Clone, Default)]
@@ -244,7 +244,7 @@ impl QueuePurgeArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`queue_delete`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.delete).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.delete).
 ///
 /// [`queue_delete`]: struct.Channel.html#method.queue_delete
 #[derive(Debug, Clone, Default)]
@@ -299,7 +299,7 @@ impl QueueDeleteArguments {
 ////////////////////////////////////////////////////////////////////////////////
 /// Arguments for [`queue_unbind`]
 ///
-/// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.unbind).
+/// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.unbind).
 ///
 /// [`queue_unbind`]: struct.Channel.html#method.queue_unbind
 #[derive(Debug, Clone, Default)]
@@ -361,7 +361,7 @@ impl QueueUnbindArguments {
 /////////////////////////////////////////////////////////////////////////////
 /// APIs for AMQP queue class.
 impl Channel {
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.declare)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.declare)
     ///
     /// If succeed, returns [`Ok`] with a optional tuple.
     ///
@@ -404,7 +404,7 @@ impl Channel {
         }
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.bind)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.bind)
     ///
     /// # Errors
     ///
@@ -438,7 +438,7 @@ impl Channel {
         Ok(())
     }
 
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.purge)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.purge)
     ///
     /// If succeed, returns [`Ok`] with a optional `message count`.
     ///
@@ -469,7 +469,7 @@ impl Channel {
             Ok(Some(purge_ok.message_count))
         }
     }
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.delete)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.delete)
     ///
     /// If succeed, returns [`Ok`] with a optional `message count`.
     ///
@@ -505,7 +505,7 @@ impl Channel {
             Ok(Some(delete_ok.message_count))
         }
     }
-    /// See [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.unbind)
+    /// See [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#queue.unbind)
     ///
     /// # Errors
     ///

--- a/amqprs/src/api/channel/tx.rs
+++ b/amqprs/src/api/channel/tx.rs
@@ -21,7 +21,7 @@ impl Channel {
     /// This method sets the channel to use standard transactions. The client must use this
     /// method at least once on a channel before using the [`tx_commit`] or [`tx_rollback`] methods.
     ///
-    /// Also see [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#tx.select).
+    /// Also see [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#tx.select).
     /// # Errors
     ///
     /// Returns error if any failure in communication with server.
@@ -45,7 +45,7 @@ impl Channel {
     /// This method commits all message publications and acknowledgments performed in
     /// the current transaction.  A new transaction starts immediately after a commit.
     ///
-    /// Also see [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#tx.commit).
+    /// Also see [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#tx.commit).
     /// # Errors
     ///
     /// Returns error if any failure in communication with server.
@@ -68,7 +68,7 @@ impl Channel {
     /// Note that unacked messages will not be automatically redelivered by rollback;
     /// if that is required an explicit recover call should be issued.
     ///
-    /// Also see [AMQP_0-9-1 Reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html#tx.rollback).
+    /// Also see [AMQP_0-9-1 Reference](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#tx.rollback).
     ///
     /// # Errors
     ///

--- a/amqprs/src/api/connection.rs
+++ b/amqprs/src/api/connection.rs
@@ -284,7 +284,7 @@ struct SharedConnectionInner {
 pub struct OpenConnectionArguments {
     /// The server host. Default: "localhost".
     host: String,
-    /// The server port. Default: 5672 by [AMQP 0-9-1 spec](https://www.rabbitmq.com/amqp-0-9-1-reference.html).
+    /// The server port. Default: 5672 by [AMQP 0-9-1 spec](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md).
     port: u16,
     /// Default: "/". See [RabbitMQ vhosts](https://www.rabbitmq.com/vhosts.html).
     virtual_host: String,
@@ -359,7 +359,7 @@ impl OpenConnectionArguments {
     ///
     /// # Default
     ///
-    /// 5672 by [AMQP 0-9-1 spec](https://www.rabbitmq.com/amqp-0-9-1-reference.html).
+    /// 5672 by [AMQP 0-9-1 spec](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md).
     pub fn port(&mut self, port: u16) -> &mut Self {
         self.port = port;
         self

--- a/amqprs/src/api/consumer.rs
+++ b/amqprs/src/api/consumer.rs
@@ -24,14 +24,14 @@ use tracing::info;
 pub trait AsyncConsumer {
     /// Consume a delivery from Server.
     ///
-    /// Every delivery combines a [Deliver](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.deliver) frame,
+    /// Every delivery combines a [Deliver](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.deliver) frame,
     /// message propertities, and content body.
     ///
     /// # Inputs
     ///
     /// `channel`: consumer's channel reference, typically used for acknowledge the delivery.
     ///
-    /// `deliver`: see [basic.deliver](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.deliver)
+    /// `deliver`: see [basic.deliver](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.deliver)
     /// or [delivery metadata](https://www.rabbitmq.com/consumers.html#message-properties)
     ///
     /// `basic_properties`: see [message properties](https://www.rabbitmq.com/consumers.html#message-properties).

--- a/amqprs/src/api/tls.rs
+++ b/amqprs/src/api/tls.rs
@@ -126,7 +126,6 @@ impl TlsAdaptor {
 
         let certs: Vec<CertificateDer> = raw_certs
             .into_iter()
-            .map(|cert| cert.map(CertificateDer::from))
             .collect::<std::io::Result<Vec<CertificateDer>>>()?;
         Ok(certs)
     }

--- a/amqprs/src/frame/content_header.rs
+++ b/amqprs/src/frame/content_header.rs
@@ -542,73 +542,73 @@ impl<'de> Deserialize<'de> for BasicProperties {
                     app_id: None,
                     cluster_id: None,
                 };
-                if (flags[0] & 1 << 7) != 0 {
+                if (flags[0] & (1 << 7)) != 0 {
                     basic_properties.content_type = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 6) != 0 {
+                if (flags[0] & (1 << 6)) != 0 {
                     basic_properties.content_encoding = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 5) != 0 {
+                if (flags[0] & (1 << 5)) != 0 {
                     basic_properties.headers = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 4) != 0 {
+                if (flags[0] & (1 << 4)) != 0 {
                     basic_properties.delivery_mode = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 3) != 0 {
+                if (flags[0] & (1 << 3)) != 0 {
                     basic_properties.priority = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 2) != 0 {
+                if (flags[0] & (1 << 2)) != 0 {
                     basic_properties.correlation_id = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 1) != 0 {
+                if (flags[0] & (1 << 1)) != 0 {
                     basic_properties.reply_to = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[0] & 1 << 0) != 0 {
+                if (flags[0] & (1 << 0)) != 0 {
                     basic_properties.expiration = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
                 // 2nd byte of flags
-                if (flags[1] & 1 << 7) != 0 {
+                if (flags[1] & (1 << 7)) != 0 {
                     basic_properties.message_id = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[1] & 1 << 6) != 0 {
+                if (flags[1] & (1 << 6)) != 0 {
                     basic_properties.timestamp = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[1] & 1 << 5) != 0 {
+                if (flags[1] & (1 << 5)) != 0 {
                     basic_properties.message_type = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[1] & 1 << 4) != 0 {
+                if (flags[1] & (1 << 4)) != 0 {
                     basic_properties.user_id = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[1] & 1 << 3) != 0 {
+                if (flags[1] & (1 << 3)) != 0 {
                     basic_properties.app_id = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 }
-                if (flags[1] & 1 << 2) != 0 {
+                if (flags[1] & (1 << 2)) != 0 {
                     basic_properties.cluster_id = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;

--- a/amqprs/src/frame/method/basic.rs
+++ b/amqprs/src/frame/method/basic.rs
@@ -112,7 +112,7 @@ pub struct ConsumeOk {
 
 /// Used by channel [`cancel`] callback.
 ///
-/// AMQP method frame [cancel](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.cancel).
+/// AMQP method frame [cancel](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.cancel).
 ///
 /// [`cancel`]: callbacks/trait.ChannelCallback.html#tymethod.cancel
 // TX + RX
@@ -187,7 +187,7 @@ impl Publish {
 
 /// Used by channel [`publish_return`] callback.
 ///
-/// AMQP method frame [return](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.return).
+/// AMQP method frame [return](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.return).
 ///
 /// [`publish_return`]: callbacks/trait.ChannelCallback.html#tymethod.publish_return
 // RX
@@ -228,7 +228,7 @@ impl Return {
 }
 /// Used by consumer [`consume`] callback.
 ///
-/// AMQP method frame [deliver](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.deliver).
+/// AMQP method frame [deliver](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.deliver).
 ///
 /// [`consume`]: consumer/trait.AsyncConsumer.html#tymethod.consume
 // RX
@@ -288,7 +288,7 @@ impl Get {
 }
 /// Part of [`GetMessage`]
 ///
-/// AMQP method frame [get-ok](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get-ok).
+/// AMQP method frame [get-ok](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.get-ok).
 ///
 /// [`GetMessage`]: channel/type.GetMessage.html
 #[derive(Debug, Serialize, Deserialize)]
@@ -336,7 +336,7 @@ pub struct GetEmpty {
 
 /// Used by channel [`publish_ack`] callback.
 ///
-/// AMQP method frame [ack](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.ack).
+/// AMQP method frame [ack](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.ack).
 ///
 /// [`publish_ack`]: callbacks/trait.ChannelCallback.html#tymethod.publish_ack
 // TX + RX
@@ -410,7 +410,7 @@ pub struct RecoverOk;
 
 /// Used by channel [`publish_nack`] callback.
 ///
-/// AMQP method frame [nack](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.nack).
+/// AMQP method frame [nack](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#basic.nack).
 ///
 /// [`publish_nack`]: callbacks/trait.ChannelCallback.html#tymethod.publish_nack
 // TX + RX

--- a/amqprs/src/frame/method/channel.rs
+++ b/amqprs/src/frame/method/channel.rs
@@ -24,7 +24,7 @@ pub struct OpenChannelOk {
 
 /// Used by channel [`close`] callback.
 ///
-/// AMQP method frame [close](https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.close).
+/// AMQP method frame [close](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#channel.close).
 ///
 /// [`close`]: callbacks/trait.ChannelCallback.html#tymethod.close
 // TX + RX

--- a/amqprs/src/frame/method/connection.rs
+++ b/amqprs/src/frame/method/connection.rs
@@ -124,7 +124,7 @@ pub struct OpenOk {
 }
 /// Used by connection's [`close`] callback.
 ///
-/// AMQP method frame [close](https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.close).
+/// AMQP method frame [close](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#connection.close).
 ///
 /// [`close`]: callbacks/trait.ConnectionCallback.html#tymethod.close
 // TX + RX


### PR DESCRIPTION
They have been moved to a GitHub repository [1].

Closes #153.

1. https://www.rabbitmq.com/amqp-0-9-1-reference.html