### PR TITLE
fix: rustls aws-lc-rs/ring compatibility by disabling default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,6 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring",
  "rustls-pki-types",
  "untrusted",
 ]

--- a/amqprs/Cargo.toml
+++ b/amqprs/Cargo.toml
@@ -51,13 +51,13 @@ uriparse = { version = "0.6", optional = true }
 serde_bytes = { workspace = true }
 
 # SSL/TLS dependencies
-tokio-rustls = { version = "0.26", optional = true }
+tokio-rustls = { version = "0.26", optional = true, default-features = false }
 rustls-pemfile = { version = "2.1.2", optional = true }
-rustls-webpki = { version = "0.102", optional = true }
+rustls-webpki = { version = "0.102", optional = true, default-features = false }
 webpki-roots = { version = "0.26", optional = true }
 rustls-pki-types = { version = "1.7.0", optional = true }
 
 [dev-dependencies]
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["aws-lc-rs"] }


### PR DESCRIPTION
Don't require rustls default features which pulls in aws-lc-rs directly and prevents applications using amqprs from using ring instead.

The dev-dependencies do depend on aws-lc-rs since they call its initialization function.

Fixes #166