### PR TITLE
Update min FRAME_MAX to match that of RabbitMQ 4.1.x

### DIFF
--- a/amqprs/src/frame/constants.rs
+++ b/amqprs/src/frame/constants.rs
@@ -12,7 +12,7 @@ pub const FRAME_HEARTBEAT: Octect = 8;
 
 pub const FRAME_END: Octect = 206;
 
-pub const FRAME_MIN_SIZE: LongUint = 4096;
+pub const FRAME_MIN_SIZE: LongUint = 8192;
 
 /// all reply code are unsigned 16bit integer
 pub const REPLY_SUCCESS: ShortUint = 200; //This reply code is reserved for future use


### PR DESCRIPTION
See Breaking Changes and Compatibility Notes in the release notes [1].

Closes #168.

1. https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Increased the minimum frame size from 4096 to 8192 for improved data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->