### PR TITLE
fix: only depend on a single version of rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde",
  "serde_bytes",
  "tokio",
@@ -1977,7 +1977,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -1992,7 +1992,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -2022,16 +2022,6 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"

--- a/amqprs/Cargo.toml
+++ b/amqprs/Cargo.toml
@@ -53,7 +53,7 @@ serde_bytes = { workspace = true }
 # SSL/TLS dependencies
 tokio-rustls = { version = "0.26", optional = true, default-features = false }
 rustls-pemfile = { version = "2.1.2", optional = true }
-rustls-webpki = { version = "0.102", optional = true, default-features = false }
+rustls-webpki = { version = "0.103", optional = true, default-features = false }
 webpki-roots = { version = "0.26", optional = true }
 rustls-pki-types = { version = "1.7.0", optional = true }
 


### PR DESCRIPTION
Change amqprs to depend on the same major version of rustls-webpki (v0.103) that tokio-rustls depends on via the rustls crate.

This avoids amqprs pulling in two different incompatible versions of the rustls-webpki crate into every application that uses it.

Fixes #172