### PR TITLE
ci: harden MSRV matrix and cap benchmarks runtime

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,15 @@
 name: bench
 run-name: "Benchmarks"
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'amqprs/**'
+      - 'amqp_serde/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yml'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,6 +18,7 @@ jobs:
 
   ubuntu:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -49,17 +49,17 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
           - '1.71'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain ${{ matrix.rust }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: cargo check (published crates, all-features)
         run: cargo check -p amqprs -p amqp_serde --all-features --locked
 


### PR DESCRIPTION
## Summary

Two small CI-hardening changes prompted by recent failures on `main`:

### 1. MSRV matrix hardening (`regression_test.yml`)
The scheduled run [24296616153](https://github.com/gftea/amqprs/actions/runs/24296616153/job/70942591143) failed in `check_msrv (1.71)` and auto-canceled the `stable` leg via the default fail-fast strategy, masking whether `stable` was also affected. PR #190 fixed the underlying MSRV compile issue; this PR prevents the cascade masking in future failures and drops the deprecated `actions-rs/toolchain@v1` action (which emits `set-output` warnings and runs on deprecated Node.js 20).

- `strategy.fail-fast: false` so each matrix leg reports independently.
- Replace `actions-rs/toolchain@v1` with the community-maintained `dtolnay/rust-toolchain@master`.

### 2. Benchmarks workflow timeout + scoping (`benchmarks.yml`)
The bench workflow run [24313268606](https://github.com/gftea/amqprs/actions/runs/24313268606/job/70986488127) on this branch is currently hanging, and the most recent bench run on `main` (at commit 6837a83) ran for 6h 5m before hitting GitHub's default 6-hour job cap — historical runs finish in 2–4 minutes. The benchmark scripts (`run_native.sh`, `run_consume_benchmark.sh`, `run_criterion.sh`) invoke `perf`, `strace`, and `criterion`, any of which can hang if RabbitMQ or the consumer loop gets stuck; without a job timeout, a hung step burns 6 hours of runner time. The workflow also currently triggers on every push to every branch with no path filter, so pushes that touch nothing benchmark-related still run the full suite.

- `timeout-minutes: 30` on the `ubuntu` job — comfortable ceiling vs. the 2–4 min typical, so hangs fail fast.
- Restrict `push` trigger to `main` with path filters covering `amqprs/`, `amqp_serde/`, `benchmarks/`, and this workflow file. `workflow_dispatch` still works from any branch for manual runs.

Root cause of the benchmark hang itself is not addressed here — that requires logs from a hung run (not currently accessible). This PR contains the workflow hardening so that future hangs cap out quickly and leave a clean failure signal to debug against.

## Test plan

- [ ] Merge and observe next scheduled `regression_test` run — both matrix legs report independently.
- [ ] Next `main` push to a benchmark-affecting path triggers `bench`; hangs now time out after 30 minutes instead of 6 hours.
- [ ] Pushes that touch only docs / unrelated workflows no longer spawn a bench run.

https://claude.ai/code/session_01B9QdycfiuFfruqYaPPx8UH