### PR TITLE
Fix clippy::explicit_counter_loop for Rust 1.95

### DIFF
--- a/amqp_serde/src/ser.rs
+++ b/amqp_serde/src/ser.rs
@@ -351,12 +351,8 @@ where
         if !self.is_len_known {
             let len: u32 = (self.ser.output.len() - self.start - 4) as u32;
 
-            let mut start = self.start;
-            for b in len.to_be_bytes() {
-                let p = self.ser.output.get_mut(start).unwrap();
-                *p = b;
-                start += 1;
-            }
+            self.ser.output[self.start..self.start + 4]
+                .copy_from_slice(&len.to_be_bytes());
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary\n\n- The scheduled CI regression test on `main` ([run #1137](https://github.com/gftea/amqprs/actions/runs/26009971534/job/76448594837)) fails at the `cargo clippy (all-features)` step with Rust 1.95's new `clippy::explicit_counter_loop` lint.\n- The flagged code in `amqp_serde/src/ser.rs:354` used a manual `start` counter to write serialized length bytes back into the output buffer.\n- Replaced the loop + counter with a single `copy_from_slice` call, which is both cleaner and eliminates the lint.\n\n## Test plan\n\n- [x] `cargo clippy --all-features -- -Dwarnings` passes on Rust 1.95\n- [x] `cargo test -p amqp_serde` — all 29 tests pass\n\nhttps://claude.ai/code/session_01B9QdycfiuFfruqYaPPx8UH

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9QdycfiuFfruqYaPPx8UH)_