### PR TITLE
Fix inconsistent traces/tracing feature gating (#154)

### DIFF
--- a/amqprs/Cargo.toml
+++ b/amqprs/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 [features]
 default = []
 compliance_assert = []
-traces = ["tracing"]
+traces = ["dep:tracing"]
 tls = [
     "tokio-rustls",
     "webpki-roots",

--- a/amqprs/src/net/writer_handler.rs
+++ b/amqprs/src/net/writer_handler.rs
@@ -55,12 +55,12 @@ impl WriterHandler {
                         Some(v) => v,
                     };
                     if let Err(err) = self.stream.write_frame(channel_id, frame, self.amqp_connection.frame_max()).await {
-                        #[cfg(feature="tracing")]
+                        #[cfg(feature = "traces")]
                         error!("failed to send frame over connection {}, cause: {}", self.amqp_connection, err);
                         break;
                     }
                     expiration = time::Instant::now() + time::Duration::from_secs(interval);
-                    #[cfg(feature="tracing")]
+                    #[cfg(feature = "traces")]
                     trace!("connection {} heartbeat deadline is updated to {:?}", self.amqp_connection, expiration);
                 }
                 _ = time::sleep_until(expiration) => {
@@ -68,16 +68,16 @@ impl WriterHandler {
                         expiration = time::Instant::now() + time::Duration::from_secs(interval);
 
                         if let Err(err) = self.stream.write_frame(DEFAULT_CONN_CHANNEL, Frame::HeartBeat(HeartBeat), self.amqp_connection.frame_max()).await {
-                            #[cfg(feature="tracing")]
+                            #[cfg(feature = "traces")]
                             error!("failed to send heartbeat over connection {}, cause: {}", self.amqp_connection, err);
                             break;
                         }
-                        #[cfg(feature="tracing")]
+                        #[cfg(feature = "traces")]
                         debug!("sent heartbeat over connection {}", self.amqp_connection,);
                     }
                 }
                 _ = self.shutdown.recv() => {
-                    #[cfg(feature="tracing")]
+                    #[cfg(feature = "traces")]
                     info!("received shutdown notification for connection {}", self.amqp_connection);
                     // try to give last chance for last message.
                     yield_now().await;

--- a/amqprs/tests/test_get.rs
+++ b/amqprs/tests/test_get.rs
@@ -76,7 +76,7 @@ async fn test_get() {
         // get single message
         let delivery_tag = match channel.basic_get(get_args.clone()).await.unwrap() {
             Some((get_ok, basic_props, content)) => {
-                #[cfg(feature = "tracing")]
+                #[cfg(feature = "traces")]
                 info!(
                     "Get results:
                     {}
@@ -114,7 +114,7 @@ async fn test_get() {
         // get single message
         let delivery_tag = match channel.basic_get(get_args.clone()).await.unwrap() {
             Some((get_ok, basic_props, content)) => {
-                #[cfg(feature = "tracing")]
+                #[cfg(feature = "traces")]
                 info!(
                     "Get results:
                     {}


### PR DESCRIPTION
## Summary

Fixes #154.

The `traces` cargo feature was inconsistently gated in the codebase:
- The Cargo.toml defined `traces = ["tracing"]`, which Cargo turned into an *implicit* `tracing` feature (because `tracing` is also an optional dependency).
- A handful of `#[cfg(...)]` checks referenced `feature = "tracing"` instead of `feature = "traces"`. Enabling `traces` happened to work because it transitively enabled the implicit `tracing` feature, but enabling `tracing` directly produced confusing partial behavior / compile errors (as reported in the issue).

### Changes

- `amqprs/Cargo.toml`: `traces = ["tracing"]` → `traces = ["dep:tracing"]`. This removes the implicit `tracing` feature entirely. MSRV 1.71 supports the `dep:` syntax.
- `amqprs/src/net/writer_handler.rs`: 5 stale `#[cfg(feature="tracing")]` → `#[cfg(feature = "traces")]`.
- `amqprs/tests/test_get.rs`: 2 stale `#[cfg(feature = "tracing")]` → `#[cfg(feature = "traces")]`.

After this change, accidentally enabling the old implicit feature produces a clear error:

```
error: the package 'amqprs' does not contain this feature: tracing
help: there is a similarly named feature: traces
```

## Test plan

- [x] `cargo build -p amqprs` (default features)
- [x] `cargo build -p amqprs --features traces`
- [x] `cargo build --all-features`
- [x] `cargo clippy --all-features -- -Dwarnings`
- [x] `cargo test --no-run -p amqprs` (default and `--features traces`)
- [x] Verified `cargo build -p amqprs --features tracing` now fails with a helpful error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMFWS54Y6Wf9hq1MjUW999)_