### PR TITLE
Add failure notification to scheduled regression tests

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -99,3 +99,31 @@ jobs:
         with:
           command: test
           args: ${{ matrix.feat }}
+
+  fire_routine_on_failure:
+    needs: [builds, check_msrv, test_examples, test_features_combination]
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST to Claude Code routine /fire
+        env:
+          ROUTINE_URL: ${{ secrets.CLAUDE_ROUTINE_URL }}
+          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          jq -n \
+            --arg t "Daily Regression Test workflow failed.
+          repository: ${{ github.repository }}
+          run_id: $RUN_ID
+          url:    $RUN_URL
+          sha:    $HEAD_SHA" \
+            '{text: $t}' > body.json
+
+          curl -fsS -X POST "$ROUTINE_URL" \
+            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            --data @body.json

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -107,8 +107,8 @@ jobs:
     steps:
       - name: POST to Claude Code routine /fire
         env:
-          ROUTINE_URL: ${{ secrets.CLAUDE_ROUTINE_URL }}
-          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
+          CLAUDE_ROUTINE_URL: ${{ secrets.CLAUDE_ROUTINE_URL }}
+          CLAUDE_ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           HEAD_SHA: ${{ github.sha }}
@@ -121,8 +121,8 @@ jobs:
           sha:    $HEAD_SHA" \
             '{text: $t}' > body.json
 
-          curl -fsS -X POST "$ROUTINE_URL" \
-            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+          curl -fsS -X POST "$CLAUDE_ROUTINE_URL" \
+            -H "Authorization: Bearer $CLAUDE_ROUTINE_TOKEN" \
             -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
             -H "anthropic-version: 2023-06-01" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
Adds a new job to the regression test workflow that sends notifications to Claude Code routine when scheduled tests fail, enabling better visibility into CI failures.

## Key Changes
- Added `fire_routine_on_failure` job that:
  - Depends on all existing test jobs (`builds`, `check_msrv`, `test_examples`, `test_features_combination`)
  - Only runs on scheduled workflow triggers when any dependent job fails
  - Sends a POST request to Claude Code routine with failure details including repository, run ID, URL, and commit SHA
  - Uses secrets for secure credential management (`CLAUDE_ROUTINE_URL` and `CLAUDE_ROUTINE_TOKEN`)

## Implementation Details
- Uses `needs` and `if` conditions to ensure the job only executes on scheduled failures
- Constructs a JSON payload with `jq` containing relevant GitHub context information
- Includes proper HTTP headers for the Claude Code routine API (authorization, beta version, content type)
- Leverages GitHub's built-in context variables (`github.run_id`, `github.sha`, `github.repository`, etc.) for dynamic payload generation

https://claude.ai/code/session_01BQgV11WYhAJuHtyk2qmhTz